### PR TITLE
Add isort

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,10 @@ universal = 1
 
 [flake8]
 ignore = E124,E501,E127,E128
+
+[isort]
+atomic=True
+balanced_wrapping=True
+line_length=119
+trailing_comma=True
+multi_line_output=4

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ django-gstorage
 
 """
 import re
+
 from setuptools import setup
 
 version = ''

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,8 @@
 -e .
-flake8
 coverage
+flake8
 gcloud
-pytest-django
-pytest-cov
+isort
 mock
+pytest-cov
+pytest-django

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,10 @@ the valid checks (gstorage.apps, gstorage.checks)
 from os import environ
 from unittest import TestCase
 
+from django.conf import settings
+from gstorage.apps import GStorageConfig
+from gstorage.checks import check_gstorage_params, get_config
+
 try:
     # python >= 3.3
     from unittest.mock import patch
@@ -13,9 +17,6 @@ except ImportError:
     # python < 3.3
     from mock import patch
 
-from django.conf import settings
-from gstorage.checks import check_gstorage_params, get_config
-from gstorage.apps import GStorageConfig
 
 key = 'GOOGLE_APPLICATION_CREDENTIALS'
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,6 @@ deps =
     -rtests/requirements.txt
 
 [testenv:py27-lint]
-deps =
-    flake8
-commands = flake8 gstorage tests
+commands =
+    flake8 gstorage tests
+    isort --check-only --recursive gstorage tests


### PR DESCRIPTION
### Purpose

Enable isort as a lint step in tox. Build should fail if isort fails.

### How to test
1. tox -e py27-lint