### PR TITLE
Add bucket.copydir that will allow files within a path to be copied to gcloud

### DIFF
--- a/gstorage/bucket.py
+++ b/gstorage/bucket.py
@@ -4,13 +4,17 @@ A thin wrapper around gcloud.bucket with convenience
 methods to interact with buckets
 
     >>> from gstorage.bucket import Bucket
-    >>> bucket = Bucket.get_or_create('pcaulagi')
-    >>> bucket.sync_dir('/share/images')
+    >>> bucket = Bucket.get_default()
+    >>> bucket.copydir('/share/images')
 """
+import os
 
+from gcloud.storage.blob import Blob
 from gcloud.storage.bucket import Bucket as BaseBucket
 from gcloud.storage.client import Client
 from oauth2client.client import GoogleCredentials
+
+from .utils import find_files, get_config
 
 
 class Bucket(BaseBucket):
@@ -23,10 +27,10 @@ class Bucket(BaseBucket):
         Args:
             bucket_name: (string) name of the bucket
         Returns:
-            an instance of bucket
+            an instance of gstorage.bucket.Bucket
         Raises:
-            400: Bad request (the name is not valid)
-            403: Forbidden (You don't have permissions for creating bucket)
+            gcloud.exceptions.BadRequest (400): not a valid bucket name
+            gcloud.exceptions.Forbidden (403): The credentials are invalid
         """
         if not client:
             credentials = GoogleCredentials.get_application_default()
@@ -35,3 +39,38 @@ class Bucket(BaseBucket):
         if not bucket.exists():
             bucket.create()
         return bucket
+
+    def copydir(self, path):
+        """
+        Copy the contents of the local directory given by path to google cloud.
+        Maintain the same directory structure on remote.
+        This is (intentionally) a blocking call, so clients can report errors if
+        the transfer fails.
+
+        Args:
+            path: (string) relative or absolute path to the directory that needs to be copied
+        Returns:
+            True if the transfer completed, else False
+        Raises:
+            OSError: path doesn't exist or permission denied
+        """
+        if not os.access(path, os.R_OK):
+            raise OSError('Permission denied')
+        for filename in find_files(path):
+            blob = Blob(filename, self)
+            blob.upload_from_filename(filename)
+
+    @classmethod
+    def get_default(cls):
+        """
+        Get an instance of the default bucket identified fy GCLOUD_DEFAULT_BUCKET_NAME
+
+        Args:
+            cls: the current class/type (gstorage.bucket.Bucket)
+        Returns:
+            an instance of gstorage.bucket.Bucket
+        Raises:
+            gcloud.exceptions.BadRequest (400): not a valid bucket name
+            gcloud.exceptions.Forbidden (403): The credentials are invalid
+        """
+        return cls.get_or_create(get_config('GCLOUD_DEFAULT_BUCKET_NAME'))

--- a/gstorage/bucket.py
+++ b/gstorage/bucket.py
@@ -50,15 +50,18 @@ class Bucket(BaseBucket):
         Args:
             path: (string) relative or absolute path to the directory that needs to be copied
         Returns:
-            True if the transfer completed, else False
+            True when transfer is completed
         Raises:
             OSError: path doesn't exist or permission denied
+            ValueError: if the library cannot determine the file size
+            gcloud.exceptions.GCloudError: if upload status gives error response
         """
         if not os.access(path, os.R_OK):
             raise OSError('Permission denied')
         for filename in find_files(path):
             blob = Blob(filename, self)
             blob.upload_from_filename(filename)
+        return True
 
     @classmethod
     def get_default(cls):

--- a/gstorage/utils.py
+++ b/gstorage/utils.py
@@ -2,7 +2,7 @@
 """
 Helper functions used by other modules
 """
-from os import environ
+import os
 
 from django.conf import settings
 
@@ -21,7 +21,21 @@ def get_config(key):
         return getattr(settings, key)
     except AttributeError:
         try:
-            return environ[key]
+            return os.environ[key]
         except KeyError:
             pass
     return None
+
+
+def find_files(path):
+    """
+    Return all the files in the given path
+
+    Args:
+        path: (string) relative or absolute path to the directory that needs to be copied
+    Returns:
+        List of string where each item is a filepath
+    """
+    return [os.path.join(dirpath, file)
+            for (dirpath, dirs, files) in os.walk(path)
+            for file in files]

--- a/gstorage/utils.py
+++ b/gstorage/utils.py
@@ -29,10 +29,10 @@ def get_config(key):
 
 def find_files(path):
     """
-    Return all the files in the given path
+    Return only the files under the given path
 
     Args:
-        path: (string) relative or absolute path to the directory that needs to be copied
+        path: (string) relative or absolute path to the directory
     Returns:
         List of string where each item is a filepath
     """

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -2,6 +2,7 @@
 """
 Tests for gstorage.bucket
 """
+import tempfile
 from mock import MagicMock, patch
 from os import environ
 from unittest import TestCase
@@ -49,3 +50,25 @@ class TestBucket(TestCase):
             with self.assertRaises(BadRequest):
                 bucket = Bucket.get_or_create('test', client='test')
                 assert bucket is None
+
+    @patch('gstorage.bucket.GoogleCredentials')
+    @patch('gstorage.bucket.get_config')
+    def test_get_default(self, mock_get_config, mock_credentials):
+        Bucket.get_default()
+        assert mock_get_config.called_once_with('GCLOUD_DEFAULT_BUCKET_NAME')
+
+    def test_copydir_noaccess(self):
+        bucket = Bucket('test')
+        with self.assertRaises(OSError):
+            bucket.copydir('/root')
+
+    @patch('gstorage.bucket.Blob')
+    def test_copydir_with_children(self, mock_blob):
+        path = tempfile.mkdtemp()
+        _, filename = tempfile.mkstemp(dir=path)
+        mock_blob.upload_from_filename = MagicMock()
+
+        bucket = Bucket('test')
+        bucket.copydir(path)
+        assert mock_blob.call_count == 1
+        # assert mock_blob.upload_from_filename.assert_called_with(filename)

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -63,13 +63,11 @@ class TestBucket(TestCase):
         with self.assertRaises(OSError):
             bucket.copydir('/root')
 
-    @patch('gstorage.bucket.Blob')
-    def test_copydir_with_children(self, mock_blob):
+    def test_copydir_with_children(self):
         path = tempfile.mkdtemp()
         _, filename = tempfile.mkstemp(dir=path)
-        mock_blob.upload_from_filename = MagicMock()
 
         bucket = Bucket('test')
-        bucket.copydir(path)
-        assert mock_blob.call_count == 1
-        # assert mock_blob.upload_from_filename.assert_called_with(filename)
+        with patch('gstorage.bucket.Blob') as mock_blob:
+            bucket.copydir(path)
+            assert mock_blob.call_count == 1

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -16,10 +16,10 @@ class TestBucket(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        try:
+        if 'GOOGLE_APPLICATION_CREDENTIALS' in environ:
             del environ['GOOGLE_APPLICATION_CREDENTIALS']
-        except KeyError:
-            pass
+        if 'GCLOUD_PROJECT' in environ:
+            del environ['GCLOUD_PROJECT']
 
     @patch('gstorage.bucket.GoogleCredentials')
     @patch('gstorage.bucket.Client')
@@ -54,6 +54,7 @@ class TestBucket(TestCase):
     @patch('gstorage.bucket.GoogleCredentials')
     @patch('gstorage.bucket.get_config')
     def test_get_default(self, mock_get_config, mock_credentials):
+        environ['GCLOUD_PROJECT'] = 'test'
         Bucket.get_default()
         assert mock_get_config.called_once_with('GCLOUD_DEFAULT_BUCKET_NAME')
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for gstorage.utils
+"""
+import tempfile
+from unittest import TestCase
+
+from gstorage.utils import find_files
+
+
+class TestUtil(TestCase):
+
+    def test_find_files_empty_directory(self):
+        path = tempfile.mkdtemp()
+        assert find_files(path) == []
+
+    def test_find_files_one_file(self):
+        path = tempfile.mkdtemp()
+        _, filename = tempfile.mkstemp(dir=path)
+        assert find_files(path) == [filename]
+
+    def test_find_files_with_children(self):
+        path = tempfile.mkdtemp()
+        _, filename = tempfile.mkstemp(dir=path)
+        child = tempfile.mkdtemp(dir=path)
+        _, child_filename = tempfile.mkstemp(dir=child)
+
+        assert find_files(path) == [filename, child_filename]


### PR DESCRIPTION
### Purpose

Adds two helper methods to gstorage.bucket and provides the following interface -

```python
>>> from gstorage.bucket import Bucket

>>> bucket = Bucket.get_default()
>>> bucket.copydir('share/storage/2016/10/01')
```

### How to test
1. `tox -e py27-django-18`
1. `tox -e py27-lint`