### PR TITLE
Storage implementation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,3 +8,4 @@ User guide
 
    bucket
    utils
+   storage

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -1,0 +1,4 @@
+.. automodule:: gstorage.storage
+
+.. autoclass:: gstorage.storage.Storage
+   :members:

--- a/gstorage/storage.py
+++ b/gstorage/storage.py
@@ -4,6 +4,13 @@ gstorage.storage
 ~~~~~~~~~~~~~~~~
 
 Implement the interface expected by :class:`django.core.files.storage.Storage`
+
+    >>> from gstorage.storage import Storage
+    >>> storage = Storage(location='images/2016')
+    >>> with open('car.jpg') as fd:
+    ...     storage.save(fd.name, fd)
+    ...
+    >>> u'images/2016/car.jpg'
 """
 import os
 
@@ -35,7 +42,7 @@ class Storage(BaseStorage):
         a proper File object or any python file-like object, ready to be read
         from the beginning.
         """
-        blob = Blob(name, self._bucket)
+        blob = Blob(os.path.join(self._location, name), self._bucket)
         blob.upload_from_file(content)
         return blob.name
 

--- a/gstorage/storage.py
+++ b/gstorage/storage.py
@@ -42,7 +42,8 @@ class Storage(BaseStorage):
         a proper File object or any python file-like object, ready to be read
         from the beginning.
         """
-        blob = Blob(os.path.join(self._location, name), self._bucket)
+        path = os.path.join(self._location, name) if self._location else name
+        blob = Blob(path, self._bucket)
         blob.upload_from_file(content)
         return blob.name
 

--- a/gstorage/storage.py
+++ b/gstorage/storage.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""
+gstorage.storage
+~~~~~~~~~~~~~~~~
+
+Implement the interface expected by :class:`django.core.files.storage.Storage`
+"""
+import os
+
+from django.core.files.storage import Storage as BaseStorage
+from django.utils.crypto import get_random_string
+from gcloud.storage.blob import Blob
+
+from .bucket import Bucket
+
+
+class Storage(BaseStorage):
+
+    def __init__(self, location=None, base_url=None, bucket=None):
+        self._location = location
+        self._base_url = base_url
+        if not bucket:
+            self._bucket = Bucket.get_default()
+        super(Storage, self).__init__()
+
+    def _open(self, name, mode):
+        """
+        Retrieves the specified file from storage.
+        """
+        return Blob(name, self._bucket)
+
+    def _save(self, name, content):
+        """
+        Saves new content to the file specified by name. The content should be
+        a proper File object or any python file-like object, ready to be read
+        from the beginning.
+        """
+        blob = Blob(name, self._bucket)
+        blob.upload_from_file(content)
+        return blob.name
+
+    def get_valid_name(self, name):
+        """
+        Returns a filename, based on the provided filename, that's suitable for
+        use in the target storage system.
+        """
+        return name
+
+    def get_available_name(self, name):
+        """
+        Returns a filename that's free on the target storage system, and
+        available for new content to be written to.
+        """
+        dir_name, file_name = os.path.split(name)
+        file_root, file_ext = os.path.splitext(file_name)
+        # If the filename already exists, add an underscore and a random 7
+        # character alphanumeric string (before the file extension, if one
+        # exists) to the filename until the generated filename doesn't exist.
+        while self.exists(name):
+            # file_ext includes the dot.
+            name = os.path.join(dir_name, "%s_%s%s" % (file_root, get_random_string(7), file_ext))
+        return name
+
+    def path(self, name):
+        """
+        Returns a local filesystem path where the file can be retrieved using
+        Python's built-in open() function. Storage systems that can't be
+        accessed using open() should *not* implement this method.
+        """
+        raise NotImplementedError("This backend doesn't support absolute paths.")
+
+    def delete(self, name):
+        """
+        Deletes the specified file from the storage system.
+        """
+        raise NotImplementedError('subclasses of Storage must provide a delete() method')
+
+    def exists(self, name):
+        """
+        Returns True if a file referenced by the given name already exists in the
+        storage system, or False if the name is available for a new file.
+        """
+        return Blob(name, self._bucket).exists()
+
+    def listdir(self, path):
+        """
+        Lists the contents of the specified path, returning a 2-tuple of lists;
+        the first item being directories, the second item being files.
+        """
+        raise NotImplementedError('subclasses of Storage must provide a listdir() method')
+
+    def size(self, name):
+        """
+        Returns the total size, in bytes, of the file specified by name.
+        """
+        raise NotImplementedError('subclasses of Storage must provide a size() method')
+
+    def url(self, name):
+        """
+        Returns an absolute URL where the file's contents can be accessed
+        directly by a Web browser.
+        """
+        return Blob(name, self._bucket).public_url
+
+    def accessed_time(self, name):
+        """
+        Returns the last accessed time (as datetime object) of the file
+        specified by name.
+        """
+        raise NotImplementedError('subclasses of Storage must provide an accessed_time() method')
+
+    def created_time(self, name):
+        """
+        Returns the creation time (as datetime object) of the file
+        specified by name.
+        """
+        raise NotImplementedError('subclasses of Storage must provide a created_time() method')
+
+    def modified_time(self, name):
+        """
+        Returns the last modified time (as datetime object) of the file
+        specified by name.
+        """
+        raise NotImplementedError('subclasses of Storage must provide a modified_time() method')

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2,7 +2,7 @@
 """
 Tests for gstorage.storage
 """
-from mock import patch
+from mock import MagicMock, patch
 from unittest import TestCase
 
 from gstorage.storage import Storage
@@ -29,6 +29,43 @@ class TestStorage(TestCase):
         s._save('test.jpg', 'r')
         mock_blob.assert_called_once_with('test.jpg', mock_bucket())
 
-    def test_get_valid_name(self, mock_bucket):
+    @patch('gstorage.storage.Blob')
+    def test_exists(self, mock_blob, mock_bucket):
+        mock_blob.exists = MagicMock()
+        s = Storage()
+        s.url('test.jpg')
+        mock_blob.exists.call_count == 1
+
+    @patch('gstorage.storage.Blob')
+    def test_url(self, mock_blob, mock_bucket):
+        mock_blob.public_url = MagicMock()
+        s = Storage()
+        s.url('test.jpg')
+        mock_blob.public_url.call_count == 1
+
+    @patch('gstorage.storage.Blob.exists')
+    def test_available_name(self, mock_exists, mock_bucket):
+        mock_exists.return_value = False
+        s = Storage()
+        assert s.get_available_name('test.jpg') == 'test.jpg'
+
+    def test_valid_name(self, mock_bucket):
         s = Storage()
         assert s.get_valid_name('test.jpg') == 'test.jpg'
+
+    def test_not_implemented(self, mock_bucket):
+        s = Storage()
+        with self.assertRaises(NotImplementedError):
+            s.listdir('test')
+        with self.assertRaises(NotImplementedError):
+            s.path('test')
+        with self.assertRaises(NotImplementedError):
+            s.delete('test')
+        with self.assertRaises(NotImplementedError):
+            s.size('test')
+        with self.assertRaises(NotImplementedError):
+            s.accessed_time('test')
+        with self.assertRaises(NotImplementedError):
+            s.created_time('test')
+        with self.assertRaises(NotImplementedError):
+            s.modified_time('test')

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,8 +1,34 @@
 # -*- coding: utf-8 -*-
-from django.test import TestCase
+"""
+Tests for gstorage.storage
+"""
+from mock import patch
+from unittest import TestCase
+
+from gstorage.storage import Storage
 
 
-class TestProject(TestCase):
+@patch('gstorage.storage.Bucket.get_default')
+class TestStorage(TestCase):
 
-    def test_true(self):
-        assert True
+    @patch('gstorage.storage.Blob')
+    def test_save_no_location(self, mock_blob, mock_bucket):
+        s = Storage()
+        s._save('test.jpg', None)
+        mock_blob.assert_called_once_with('test.jpg', mock_bucket())
+
+    @patch('gstorage.storage.Blob')
+    def test_save_with_location(self, mock_blob, mock_bucket):
+        s = Storage(location='images')
+        s._save('test.jpg', None)
+        mock_blob.assert_called_once_with('images/test.jpg', mock_bucket())
+
+    @patch('gstorage.storage.Blob')
+    def test_open(self, mock_blob, mock_bucket):
+        s = Storage()
+        s._save('test.jpg', 'r')
+        mock_blob.assert_called_once_with('test.jpg', mock_bucket())
+
+    def test_get_valid_name(self, mock_bucket):
+        s = Storage()
+        assert s.get_valid_name('test.jpg') == 'test.jpg'


### PR DESCRIPTION
### Purpose

This is a first stab at implementing the interfaces specified in `django.core.files.storage.Storage`. The only tested implementation is _save, though the other methods are probable close to what we want to use.

```
>>> from gstorage.storage import Storage
>>> storage = Storage(location='images/2016')
>>> with open('car.jpg') as fd:
...     storage.save(fd.name, fd)
...
>>> u'images/2016/car.jpg'
```

### How to test
1. `tox -e py27-django-17`
1. `tox -e py27-lint`